### PR TITLE
ENH Add safe SLOPE solver

### DIFF
--- a/solvers/pgd_safe_screening.py
+++ b/solvers/pgd_safe_screening.py
@@ -26,7 +26,6 @@ class Solver(BaseSolver):
 
     def set_objective(self, X, y, alphas, fit_intercept):
         self.X, self.y, self.alphas = X, y, alphas
-        self.n_samples = len(y)
         self.fit_intercept = fit_intercept
 
         self.param = SlopeParameters()
@@ -48,7 +47,7 @@ class Solver(BaseSolver):
         self.param.max_it = it
 
         self.coef_ = slope_gp(
-            self.y, self.X, 1.0, self.alphas * self.n_samples, self.param
+            self.y, self.X, 1.0, self.alphas * len(self.y), self.param
         )["sol"]
 
     def get_result(self):

--- a/solvers/pgd_safe_screening.py
+++ b/solvers/pgd_safe_screening.py
@@ -30,7 +30,7 @@ class Solver(BaseSolver):
         self.fit_intercept = fit_intercept
 
         self.param = SlopeParameters()
-        self.param.accelerated = False
+        self.param.accelerated = self.accelerated
         self.param.gap_stopping = 0
         self.param.eval_gap_it = 10
         self.param.verbose = False
@@ -45,7 +45,6 @@ class Solver(BaseSolver):
         return False, None
 
     def run(self, it):
-        self.param.accelerated = self.accelerated
         self.param.max_it = it
 
         self.coef_ = slope_gp(

--- a/solvers/pgd_safe_screening.py
+++ b/solvers/pgd_safe_screening.py
@@ -9,7 +9,7 @@ with safe_import_context() as import_ctx:
 
 
 class Solver(BaseSolver):
-    name = "Safe"
+    name = "PGD_safe_screening"
     stopping_strategy = "iteration"
     install_cmd = "conda"
     requirements = [

--- a/solvers/safe.py
+++ b/solvers/safe.py
@@ -1,5 +1,6 @@
 from benchopt import BaseSolver, safe_import_context
 
+
 with safe_import_context() as import_ctx:
     import numpy as np
     from scipy import sparse

--- a/solvers/safe.py
+++ b/solvers/safe.py
@@ -1,0 +1,54 @@
+from benchopt import BaseSolver, safe_import_context
+from benchopt.stopping_criterion import SufficientProgressCriterion
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from scipy import sparse
+    from slopescreening.solver.parameters import SlopeParameters
+    from slopescreening.solver.slope import slope_gp
+
+
+class Solver(BaseSolver):
+    name = "Safe"
+    stopping_strategy = "iteration"
+    install_cmd = "conda"
+    requirements = [
+        "pip:git+https://gitlab-research.centralesupelec.fr/2020elvirac/slope-screening@master"
+    ]
+    references = [
+        "C. Elvira and C. Herzet, “Safe rules for the identification of zeros in the solutions of the SLOPE problem.” arXiv, Oct. 04, 2022. doi: 10.48550/arXiv.2110.11784."
+    ]
+    parameters = {
+        "accelerated": [True, False],
+    }
+
+    def set_objective(self, X, y, alphas, fit_intercept):
+        self.X, self.y, self.alphas = X, y, alphas
+        self.n_samples = len(y)
+        self.fit_intercept = fit_intercept
+
+        self.param = SlopeParameters()
+        self.param.accelerated = False
+        self.param.gap_stopping = 0
+        self.param.eval_gap_it = 10
+        self.param.verbose = False
+
+    def skip(self, X, y, alphas, fit_intercept):
+        if fit_intercept:
+            return True, f"{self.name} does not handle intercept fitting"
+
+        if sparse.issparse(X):
+            return True, f"{self.name} does not handle sparse design matrices"
+
+        return False, None
+
+    def run(self, it):
+        self.param.accelerated = self.accelerated
+        self.param.max_it = it
+
+        self.coef_ = slope_gp(
+            self.y, self.X, 1.0, self.alphas * self.n_samples, self.param
+        )["sol"]
+
+    def get_result(self):
+        return np.hstack((np.array([0.0]), self.coef_))

--- a/solvers/safe.py
+++ b/solvers/safe.py
@@ -1,0 +1,55 @@
+from benchopt import BaseSolver, safe_import_context
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    from scipy import sparse
+    from slopescreening.solver.parameters import SlopeParameters
+    from slopescreening.solver.slope import slope_gp
+
+
+class Solver(BaseSolver):
+    name = "Safe"
+    stopping_strategy = "iteration"
+    install_cmd = "conda"
+    requirements = [
+        "pip:git+https://gitlab-research.centralesupelec.fr/2020elvirac/slope-screening@master"
+    ]
+    references = [
+        "C. Elvira and C. Herzet, “Safe rules for the identification of zeros in ",
+        "the solutions of the SLOPE problem.” arXiv, Oct. 04, 2022. ",
+        "doi: 10.48550/arXiv.2110.11784.",
+    ]
+    parameters = {
+        "accelerated": [True, False],
+    }
+
+    def set_objective(self, X, y, alphas, fit_intercept):
+        self.X, self.y, self.alphas = X, y, alphas
+        self.n_samples = len(y)
+        self.fit_intercept = fit_intercept
+
+        self.param = SlopeParameters()
+        self.param.accelerated = False
+        self.param.gap_stopping = 0
+        self.param.eval_gap_it = 10
+        self.param.verbose = False
+
+    def skip(self, X, y, alphas, fit_intercept):
+        if fit_intercept:
+            return True, f"{self.name} does not handle intercept fitting"
+
+        if sparse.issparse(X):
+            return True, f"{self.name} does not handle sparse design matrices"
+
+        return False, None
+
+    def run(self, it):
+        self.param.accelerated = self.accelerated
+        self.param.max_it = it
+
+        self.coef_ = slope_gp(
+            self.y, self.X, 1.0, self.alphas * self.n_samples, self.param
+        )["sol"]
+
+    def get_result(self):
+        return np.hstack((np.array([0.0]), self.coef_))


### PR DESCRIPTION
This PR adds support for a SLOPE solver based on the safe screening rule for SLOPE by Elvira and Herzet (https://arxiv.org/abs/2110.11784). The implementation is located at https://gitlab-research.centralesupelec.fr/2020elvirac/slope-screening/-/tree/master. I believe this is a ISTA/FISTA implementation, so in the future we may just want to add the rule to the PGD solver we have instead and also add the strong screening rule for better comparisons. I discussed this with Clemént who was positive to the idea.

Here are some results. I believe the reason that rSLOPE (also FISTA) is faster most of the time is that it's a C++-based implementation whereas the safe screening rule implementation is mostly python-based.

![image](https://user-images.githubusercontent.com/13087841/201871751-ed660527-58f4-42cc-a82f-89cfaa048776.png)

![image](https://user-images.githubusercontent.com/13087841/201871827-689544d2-dc5e-40f9-9a75-c6a12a8c0972.png)

![image](https://user-images.githubusercontent.com/13087841/201871860-327af688-499f-44e2-8c47-8448889ac2a9.png)
