### PR TITLE
ci: remove benchopt_release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,5 @@ jobs:
     uses: benchopt/template_benchmark/.github/workflows/test_benchmarks.yml@main
     with:
       benchopt_branch: benchopt@main
-  benchopt_release:
-    uses: benchopt/template_benchmark/.github/workflows/test_benchmarks.yml@main
-    with:
-      benchopt_version: latest
   lint:
     uses: benchopt/template_benchmark/.github/workflows/lint_benchmarks.yml@main


### PR DESCRIPTION
The benchopt test workflow for the release version is failing. This PR turns it off for now to avoid the multiple errors this is currently causing. When https://github.com/benchopt/template_benchmark/issues/43 is resolved, we can turn it back on.