### PR TITLE
fix(sortedl1): use custom `get_next()` method

### DIFF
--- a/solvers/sortedl1.py
+++ b/solvers/sortedl1.py
@@ -47,5 +47,12 @@ class Solver(BaseSolver):
             else:
                 self.coef = np.hstack(([0.0], coef))
 
+    @staticmethod
+    def get_next(prev_tol):
+        if prev_tol == INFINITY:
+            return 0.1
+        else:
+            return prev_tol / 5
+
     def get_result(self):
         return dict(beta=self.coef)


### PR DESCRIPTION
The solver is stopping prematurely otherwise.