### PR TITLE
fix(sortedl1): limit tolerance

### DIFF
--- a/solvers/sortedl1.py
+++ b/solvers/sortedl1.py
@@ -52,7 +52,8 @@ class Solver(BaseSolver):
         if prev_tol == INFINITY:
             return 0.1
         else:
-            return prev_tol / 5
+            tol = max(prev_tol / 5, 1e-7)
+            return tol
 
     def get_result(self):
         return dict(beta=self.coef)


### PR DESCRIPTION
For some datasets, setting the tolerance to a low value for the sortedl1 solver causes convergence issues.