### PR TITLE
fix: use `fetch_libsvm`

### DIFF
--- a/datasets/libsvm.py
+++ b/datasets/libsvm.py
@@ -1,7 +1,7 @@
 from benchopt import BaseDataset, safe_import_context
 
 with safe_import_context() as import_ctx:
-    from libsvmdata import fetch_dataset
+    from libsvmdata import fetch_libsvm
     from scipy import sparse
     from sklearn.feature_selection import VarianceThreshold
     from sklearn.preprocessing import MaxAbsScaler, StandardScaler
@@ -29,7 +29,7 @@ class Dataset(BaseDataset):
         self.standardize = standardize
 
     def get_data(self):
-        X, y = fetch_dataset(self.dataset)
+        X, y = fetch_libsvm(self.dataset)
 
         if self.standardize:
             X = VarianceThreshold().fit_transform(X)


### PR DESCRIPTION
`fetch_dataset` is not available in the current pypi release of libsvmdata.