### PR TITLE
fix: use `::` in pip+git requirement

### DIFF
--- a/solvers/pgd_safe_screening.py
+++ b/solvers/pgd_safe_screening.py
@@ -11,9 +11,7 @@ class Solver(BaseSolver):
     name = "PGD_safe_screening"
     sampling_strategy = "iteration"
     install_cmd = "conda"
-    requirements = ["pip:git+https://github.com/c-elvira/slopescreening"]
-    # TODO when benchopt 1.7 is released, update to
-    # "pip::git+https://github.com/c-elvira/slopescreening"
+    requirements = ["pip::git+https://github.com/c-elvira/slopescreening"]
 
     references = [
         "C. Elvira and C. Herzet, “Safe rules for the identification of zeros in ",

--- a/solvers/slope_path.py
+++ b/solvers/slope_path.py
@@ -10,9 +10,7 @@ class Solver(BaseSolver):
     name = "SlopePath"
     sampling_strategy = "iteration"
     install_cmd = "conda"
-    requirements = ["pip:git+https://github.com/jolars/slope-path"]
-    # TODO when benchopt 1.7 is released, update to
-    # "pip::git..."
+    requirements = ["pip::git+https://github.com/jolars/slope-path"]
 
     references = [
         "Dupuis, X., & Tardivel, P. (2024). The solution path of SLOPE. "


### PR DESCRIPTION
Small fix for requirements to use `::` in pip+git style requirements.